### PR TITLE
Allow manufacturer order number to be Null 

### DIFF
--- a/socrates_api/serializers.py
+++ b/socrates_api/serializers.py
@@ -109,7 +109,7 @@ class WarrantySerializer(serializers.Serializer):
     valid = serializers.BooleanField(default=False)
     shipping_date = serializers.DateTimeField(required=False)
     next_end_date = serializers.DateTimeField(required=False, allow_null=True)
-    order_number = serializers.CharField(required=False)
+    order_number = serializers.CharField(required=False, allow_null=True)
     entitlements = serializers.DictField(required=False, child=WarrantyEntitlementSerializer())
 
 class AssetSerializer(NeedsReviewMixin, HistorySerializerMixin):

--- a/socrates_api/tasks.py
+++ b/socrates_api/tasks.py
@@ -1035,7 +1035,7 @@ def add_to_dns(asset, old_asset=None):
             changed = True
             old_network = NetworkSerializer.get_by_asset_vlan(old_asset, old_asset['provision']['vlan'])
             if 'ip' in old_asset['provision']['vlan']:
-                ipam.ip_address_remove(old_network, asset, old_asset['provision']['hostname'], old_asset['provision']['vlan']['ip']) 
+                ipam.ip_address_remove(old_network, asset, old_asset['provision']['hostname'], old_asset['provision']['vlan']['ip'])
             new_network = NetworkSerializer.get_by_asset_vlan(asset, asset['provision']['vlan'])
             kwargs = {}
             if 'ip' in asset['provision']['vlan'] and ipv4_network_contains(asset['provision']['vlan']['cidr'], asset['provision']['vlan']['ip']):

--- a/socrates_api/tasks.py
+++ b/socrates_api/tasks.py
@@ -444,9 +444,10 @@ def _extract_dell_warranty_from_raw(service_tag):
                             entitlements[stype] = {'description': e['ServiceLevelDescription'], 'end_date': current_end_date}
                             if not next_end_date or current_end_date < next_end_date:
                                 next_end_date = current_end_date
+        if warranty['AssetHeaderData']['OrderNumber']:
+            data['order_number'] = warranty['AssetHeaderData']['OrderNumber']
         data['entitlements'] = entitlements
         data['shipping_date'] = pytz.utc.localize(datetime.datetime.strptime(warranty['AssetHeaderData']['ShipDate'], "%Y-%m-%dT%H:%M:%S"))
-        data['order_number'] = warranty['AssetHeaderData']['OrderNumber']
         data['next_end_date'] = next_end_date
         data['valid'] = True
     else:


### PR DESCRIPTION
when a certain manufacturers warranty expired, their api will not return order numbers but an empty string.

Not sure if this is the case, but it seems that an empty string is considered null, guessing this happens in django_rethink but I'm not sure and I don't see any harm in allowing order number to be null since the "manufacturer" throws away the orders upon expiry.