### PR TITLE
Some vendor specific fixes and possible efi boot mode handling

### DIFF
--- a/contrib/intake/intake-controller.py
+++ b/contrib/intake/intake-controller.py
@@ -16,22 +16,22 @@ def run(options, steps):
 
     try:
         system = dmidecode.system()
-        system_manufacturer = [v for k, v in system.iteritems() if 'Manufacturer' in v['data']][0]['data']['Manufacturer']
+        system_manufacturer = [v for k, v in system.items() if 'Manufacturer' in v['data']][0]['data']['Manufacturer']
         if system_manufacturer.startswith("HP"):
             system_manufacturer = "HP"
-            model = [v for k, v in system.iteritems() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
-            asset_tag = [v for k, v in system.iteritems() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
+            model = [v for k, v in system.items() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
+            asset_tag = [v for k, v in system.items() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
         elif system_manufacturer.startswith("Dell"):
             system_manufacturer = "Dell"
-            model = [v for k, v in system.iteritems() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
-            asset_tag = [v for k, v in system.iteritems() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
+            model = [v for k, v in system.items() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
+            asset_tag = [v for k, v in system.items() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
         elif system_manufacturer.startswith("Supermicro"):
             system_manufacturer = "Supermicro"
             baseboard = dmidecode.baseboard()
-            model = [v for k, v in system.iteritems() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
+            model = [v for k, v in system.items() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
             if model in ('Super Server', 'To be filled by O.E.M.'):
-                model = [v for k, v in baseboard.iteritems() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
-            asset_tag = [v for k, v in baseboard.iteritems() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
+                model = [v for k, v in baseboard.items() if 'Product Name' in v['data']][0]['data']['Product Name'].strip()
+            asset_tag = [v for k, v in baseboard.items() if 'Serial Number' in v['data']][0]['data']['Serial Number'].strip()
         else:
             raise Exception("Unknown")
     except:

--- a/contrib/intake/intake.py
+++ b/contrib/intake/intake.py
@@ -11,6 +11,7 @@ from common import *
 
 def main(system_manufacturer, model, asset_tag, configuration_file):
     dev_null = open("/dev/null", "w")
+    is_efi = os.path.exists("/sys/firmware/efi")
     interfaces = filter(lambda x: not x.startswith("lo"), netifaces.interfaces())
     lshw_rc, lshw_out, lshw_err = call_with_output(["lshw", "-json"], 'Failed to run lshw with %(returncode)d:\n%(err)s')
     lshw_dict = json.loads(lshw_out)
@@ -56,6 +57,8 @@ def main(system_manufacturer, model, asset_tag, configuration_file):
                 ipmicfg['chassis'] = m.group(1)
 
     oob = {}
+    subprocess.call(["modprobe", "ipmi_devintf"])
+    time.sleep(3)
 
     p = subprocess.Popen(["ipmitool", "mc", "info"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     ipmitool_mc_out, ipmitool_mc_err = p.communicate()
@@ -100,6 +103,7 @@ def main(system_manufacturer, model, asset_tag, configuration_file):
         'by_id_map': by_id_map,
         'oob': oob,
         'ipmicfg': ipmicfg,
+        'efi': is_efi,
     }, sys.stdout)
 
 if __name__ == "__main__":

--- a/contrib/intake/pxe-boot.py
+++ b/contrib/intake/pxe-boot.py
@@ -2,17 +2,27 @@
 
 import sys
 import json
+import re
 from common import call_with_output
 
 def main(system_manufacturer, model, asset_tag, configuration_file):
     if system_manufacturer == "Dell":
-        rc, out, err = call_with_output(["racadm", "get", "BIOS.BiosBootSettings.BootSeq"], "Failed to list BIOS boot devices: %(returncode)s\n%(out)s%(err)s", success=[0, 1, 2])
+        bootseq_mode = "BootSeq"
+        rc, out, err = call_with_output(['racadm', 'get', 'BIOS.BiosBootSettings'], 'Failed to get BIOS boot mode: %(returncode)s\n%(out)s%(err)s', success=[0, 1, 2])
+        for line in out.splitlines():
+            if re.match('^BootMode=Uefi', line, re.I):
+                bootseq_mode = "UefiBootSeq"
+        rc, out, err = call_with_output(["racadm", "get", "BIOS.BiosBootSettings.{0}".format(bootseq_mode)], "Failed to list BIOS boot devices: %(returncode)s\n%(out)s%(err)s", success=[0, 1, 2])
         if rc == 0:
-            call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeBootMode", "OneTimeBootSeq"], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
-            one_time_boot = filter(lambda x: not x.startswith("HardDisk") and not x.startswith("RAID"),
-                    filter(lambda x: x.startswith("BootSeq="), out.splitlines())[0][8:].split(",")
-                )[0]
-            call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeBootSeqDev", one_time_boot], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
+            if bootseq_mode != 'UefiBootSeq':
+                call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeBootMode", "OneTimeBootSeq"], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
+                one_time_boot = filter(lambda x: not x.startswith("HardDisk") and not x.startswith("RAID"),
+                        filter(lambda x: x.startswith("BootSeq="), out.splitlines())[0][8:].split(",")
+                    )[0]
+                call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeBootSeqDev", one_time_boot], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
+            else:
+                call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeBootMode", "OneTimeUefiBootSeq"], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
+                call_with_output(["racadm", "set", "BIOS.OneTimeBoot.OneTimeUefiBootSeqDev", 'NIC.PxeDevice.1-1'], "Failed to enable one-time-boot: %(returncode)s\n%(out)s%(err)s")
             call_with_output(["racadm", "jobqueue", "create", "BIOS.Setup.1-1", "-r", "pwrcycle", "-s", "TIME_NOW", "-e", "TIME_NA"], "Failed to schedule BIOS job: %(returncode)s\n%(out)s%(err)s")
     else:
         rc = 1

--- a/contrib/intake/raid-config.py
+++ b/contrib/intake/raid-config.py
@@ -23,7 +23,7 @@ HP_RAID_LEVELS = {
     'RAID-10': '1+0',
 }
 def hp_same_config(old_vdisk, new_vdisks):
-    for disk_name, new_vdisk in new_vdisks.iteritems():
+    for disk_name, new_vdisk in new_vdisks.items():
         if (
             old_vdisk['FaultTolerance'] == HP_RAID_LEVELS.get(new_vdisk['raid'], None) and
             set(map(lambda x: x['ID'], old_vdisk['pdisks'])) == set(map(lambda x: x['id'], new_vdisk['pdisks']))
@@ -63,7 +63,7 @@ def main(system_manufacturer, model, asset_tag, configuration_file):
             if clear_foreign:
                 call_with_output(["omconfig", "storage", "controller", "action=clearforeignconfig", "controller=%s" % controller['ID']], "Failed to clear foreign config: %(returncode)s\n%(out)s%(err)s")
 
-        for disk in sorted(configuration['storage'].iteritems(), key=lambda v: 0 if v[0] == 'os' else 1):
+        for disk in sorted(configuration['storage'].items(), key=lambda v: 0 if v[0] == 'os' else 1):
             disk_name, disk = disk
             if disk_name in good_vdisks:
                 continue
@@ -138,7 +138,7 @@ def main(system_manufacturer, model, asset_tag, configuration_file):
                     result['vdisks_by_id'][disk_name] = vdisk['DiskName']
 
 
-        for disk in sorted(configuration['storage'].iteritems(), key=lambda v: 0 if v[0] == 'os' else 1):
+        for disk in sorted(configuration['storage'].items(), key=lambda v: 0 if v[0] == 'os' else 1):
             disk_name, disk = disk
             if disk_name in good_vdisks:
                 continue
@@ -181,7 +181,7 @@ def main(system_manufacturer, model, asset_tag, configuration_file):
                     good_vdisks.append(vdisk['name'])
                     result['vdisks_by_id'][vdisk['name']] = vdisk['by_id']
 
-        for disk in sorted(configuration['storage'].iteritems(), key=lambda v: 0 if v[0] == 'os' else 1):
+        for disk in sorted(configuration['storage'].items(), key=lambda v: 0 if v[0] == 'os' else 1):
             disk_name, disk = disk
             if disk_name in good_vdisks:
                 continue

--- a/socrates_api/serializers.py
+++ b/socrates_api/serializers.py
@@ -125,6 +125,7 @@ class AssetSerializer(NeedsReviewMixin, HistorySerializerMixin):
     switch = serializers.DictField(required=False)
     network = serializers.DictField(required=False)
     cards = serializers.ListField(child=serializers.DictField(), required=False)
+    efi = serializers.BooleanField(required=False)
     # Field generated from warranty API
     warranty = WarrantySerializer(required=False)
     # Timestamps

--- a/socrates_api/tasks.py
+++ b/socrates_api/tasks.py
@@ -93,7 +93,7 @@ def extract_asset_from_raw(service_tag, final_step=False):
     conn = get_connection()
     raw_asset = next(r.table("assets_raw").get_all(service_tag, index="service_tag").run(conn))
     data = {}
-    data['efi'] = raw_asset['intake'].get('efi')
+    data['efi'] = raw_asset['intake'].get('efi', False)
     data['cpu'] = [x.value for x in jsonpath_rw_ext.parse('$..children[?class="processor"].version').find(raw_asset)]
     try:
         memory = jsonpath_rw_ext.parse('$..children[?id="memory"]').find(raw_asset)[0].value
@@ -799,7 +799,7 @@ def ipmi_reboot(self, asset):
 def ipmi_boot_pxe(self, asset):
     pxe_boot_command = asset['service_tag'], asset['oob']['username'], asset['oob']['password'], ['chassis', 'bootdev', 'pxe']
     if asset['asset_type'] == 'server':
-        if asset.get('efi'):
+        if asset.get('efi', False):
             pxe_boot_command.append('options=efiboot')
         try:
             ipmi_command(pxe_boot_command)

--- a/socrates_api/tasks.py
+++ b/socrates_api/tasks.py
@@ -93,6 +93,7 @@ def extract_asset_from_raw(service_tag, final_step=False):
     conn = get_connection()
     raw_asset = next(r.table("assets_raw").get_all(service_tag, index="service_tag").run(conn))
     data = {}
+    data['efi'] = raw_asset['intake'].get('efi')
     data['cpu'] = [x.value for x in jsonpath_rw_ext.parse('$..children[?class="processor"].version').find(raw_asset)]
     try:
         memory = jsonpath_rw_ext.parse('$..children[?id="memory"]').find(raw_asset)[0].value
@@ -796,9 +797,12 @@ def ipmi_reboot(self, asset):
 
 @shared_task(bind=True)
 def ipmi_boot_pxe(self, asset):
+    pxe_boot_command = asset['service_tag'], asset['oob']['username'], asset['oob']['password'], ['chassis', 'bootdev', 'pxe']
     if asset['asset_type'] == 'server':
+        if asset.get('efi'):
+            pxe_boot_command.append('options=efiboot')
         try:
-            ipmi_command(asset['service_tag'], asset['oob']['username'], asset['oob']['password'], ['chassis', 'bootdev', 'pxe'])
+            ipmi_command(pxe_boot_command)
         except IPMIException as e:
             self.retry(exc=e, countdown=3, max_retries=40)
     return asset


### PR DESCRIPTION
As title suggests, this PR handle some new "features" added to a specific vendor tool in the intake scripts, it also tries to determine if the asset was booted in efi mode and set "efi" in the asset accordingly, this is due to ipmi_tool (and others) need to append options when setting next boot mode if efi is used, default is bios.

Also, some iteritems() have been replaced with items(), since python3 deprectaed the use of iteritems()