### PR TITLE
remove_network_ovirt: correct API call, delete the expected network

### DIFF
--- a/socrates_api/tasks.py
+++ b/socrates_api/tasks.py
@@ -1901,12 +1901,16 @@ def add_network_ovirt(asset, network):
 def remove_network_ovirt(asset, network):
     api, datacenter, cluster = connect_hypervisor_ovirt(asset)
     name = network['domains'][asset['service_tag']]['name']
-    vnic_profile = api.system_service().vnic_profiles_service().list(name=name)
-    if vnic_profile:
-        api.system_service().vnic_profiles_service().vnic_profile_service(vnic_profile[0].id).remove()
-    network = api.system_service().networks_service().list(name=name)
-    if network:
-        api.system_service().networks_service().network_service(network[0].id).remove()
+    vnic_profiles = [x for x in api.system_service().vnic_profiles_service().list() if x.name == name]
+    for profile in vnic_profiles:
+        logger.info("Removing oVirt vNIC profile %s with ID %s", profile.name, profile.id)
+        api.system_service().vnic_profiles_service().profile_service(profile.id).remove()
+        break
+    ovirt_networks = [x for x in api.system_service().networks_service().list() if x.name == name]
+    for ovirt_net in ovirt_networks:
+        logger.info("Removing oVirt logical network %s with ID %s", ovirt_net.name, ovirt_net.id)
+        api.system_service().networks_service().network_service(ovirt_net.id).remove()
+        break
     api.close()
     return asset
 


### PR DESCRIPTION
The original code produced the following error when executed:

    Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 375, in trace_task
        R = retval = fun(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 632, in __protected_call__
        return self.run(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/socrates_api/tasks.py", line 2744, in remove_network
        return remove_network_ovirt(asset, network)
      File "/usr/lib/python2.7/site-packages/socrates_api/tasks.py", line 1870, in remove_network_ovirt
        api.system_service().vnic_profiles_service().vnic_profile_service(vnic_profile[0].id).remove()
    AttributeError: 'VnicProfilesService' object has no attribute 'vnic_profile_service'

After renaming the `vnic_profile_service` to `profile_service` it was discovered that the `.list(name=name)` filtering didn't work as intended.  ovirt-engine-sdk-python 4.2.9 appears to warn about an unsupported `name` parameter whereas all the 4.3 releases accept it and return full, non-filtered lists.  That usually caused the wrong vNIC profile and network to be deleted.

The `break` statements are purely a protective measure.