### PR TITLE
[WIP] allow port-ranges in firewall rules

### DIFF
--- a/socrates_api/serializers.py
+++ b/socrates_api/serializers.py
@@ -620,12 +620,12 @@ class FirewallAddressGroupSerializer(HistorySerializerMixin):
 def validate_firewall_ports(port):
     if ':' in port:
         port_range = port.split(':')
-        if not all([i.isalnum() for i in port_range]):
+        if not all([i.isdigit() for i in port_range]):
             raise serializers.ValidationError('invalid port characters: {0}'.format(port))
         if len(port_range) != 2:
             raise serializers.ValidationError('invalid port range length {0}, required length is 2'.format(len(port_range)))
         return port
-    if not port.isalnum():
+    if not port.isdigit():
         raise serializers.ValidationError('invalid port characters: {0}'.format(port))
     return port
 

--- a/socrates_api/serializers.py
+++ b/socrates_api/serializers.py
@@ -618,7 +618,7 @@ class FirewallAddressGroupSerializer(HistorySerializerMixin):
         return reverse('socrates_api:firewall_addressgroup_detail', kwargs={'slug': instance['name']}, request=self.context.get('request'))
 
 def validate_port_number(port):
-    if 0 < port >= 65535:
+    if 0 < port <= 65535:
         return True
     raise serializers.ValidationError('{0} is outside valid port numbers 0, 65535'.format(port))
 

--- a/socrates_api/serializers.py
+++ b/socrates_api/serializers.py
@@ -617,6 +617,18 @@ class FirewallAddressGroupSerializer(HistorySerializerMixin):
     def create_link(self, instance):
         return reverse('socrates_api:firewall_addressgroup_detail', kwargs={'slug': instance['name']}, request=self.context.get('request'))
 
+def validate_firewall_ports(port):
+    if ':' in port:
+        port_range = port.split(':')
+        if not all([i.isalnum() for i in port_range]):
+            raise serializers.ValidationError('invalid port characters: {0}'.format(port))
+        if len(port_range) != 2:
+            raise serializers.ValidationError('invalid port range length {0}, required length is 2'.format(len(port_range)))
+        return port
+    if not port.isalnum():
+        raise serializers.ValidationError('invalid port characters: {0}'.format(port))
+    return port
+
 class FirewallRuleSerializer(serializers.Serializer):
     type = serializers.ChoiceField(required=True, choices=['ingress', 'egress'])
     expiration = serializers.DateTimeField(required=False)
@@ -633,18 +645,6 @@ def validate_ruleset_name(name):
     except RethinkObjectNotFound:
         raise serializers.ValidationError("ruleset '%s' does not exist" % name)
     return name
-
-def validate_firewall_ports(port):
-    if ':' in port:
-        port_range = port.split(':')
-        if not all([i.isalnum() for i in port_range]):
-            raise serializersValidationError('invalid port characters: {0}'.format(ports))
-        if len(port_range) != 2:
-            raise serializersValidationError('invalid port range length {0}, required length is 2'.format(len(port_range)))
-        return port
-    if not port.isalnum():
-        raise serializersValidationError('invalid port characters: {0}'.format(port))
-    return port
 
 class FirewallRuleSetSerializer(HistorySerializerMixin):
     id = serializers.CharField(required=False)

--- a/socrates_api/tests.py
+++ b/socrates_api/tests.py
@@ -1267,7 +1267,7 @@ class APITests(BaseTests):
                         'source_addresses': [
                             {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
                         ],
-                        'destination_ports': ['4000:4050'],
+                        'destination_ports': [{'start': 9000, 'end': 9090}],
                     },
                     {
                         'type': 'egress',
@@ -1292,7 +1292,7 @@ class APITests(BaseTests):
                         'source_addresses': [
                             {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
                         ],
-                        'destination_ports': ['8080:808o'],
+                        'destination_ports': [{'start': 8080, 'end': '8090'}],
                     },
                     {
                         'type': 'egress',
@@ -1316,7 +1316,7 @@ class APITests(BaseTests):
                         'source_addresses': [
                             {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
                         ],
-                        'destination_ports': ['8080:8085:9099'],
+                        'destination_ports': [{'start': 8443}],
                     },
                     {
                         'type': 'egress',
@@ -1340,7 +1340,7 @@ class APITests(BaseTests):
                         'source_addresses': [
                             {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
                         ],
-                        'destination_ports': ['8080;8085'],
+                        'destination_ports': [{'start': 41000, 'end': 40000}],
                     },
                     {
                         'type': 'egress',

--- a/socrates_api/tests.py
+++ b/socrates_api/tests.py
@@ -1258,6 +1258,81 @@ class APITests(BaseTests):
             }), content_type="application/json", HTTP_AUTHORIZATION=auth)
         self.assertResponse(response, 201)
 
+        response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
+                'name': 'ruleset_faulty1',
+                'rulesets': ['ruleset1'],
+                'rules': [
+                    {
+                        'type': 'ingress',
+                        'protocol': 'tcp',
+                        'source_addresses': [
+                            {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
+                        ],
+                        'destination_ports': ['8080:808o'],
+                    },
+                    {
+                        'type': 'egress',
+                        'protocol': 'tcp',
+                        'destination_addresses': [
+                            {'address_group': 'testgroup'},
+                            {'vrf': 0, 'address': '10.0.1.12', 'length': 32},
+                        ],
+                        'destination_ports': [443],
+                    },
+                ]
+            }), content_type="application/json", HTTP_AUTHORIZATION=auth)
+        self.assertResponse(response, 400)
+
+        response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
+                'name': 'ruleset_faulty1',
+                'rulesets': ['ruleset1'],
+                'rules': [
+                    {
+                        'type': 'ingress',
+                        'protocol': 'tcp',
+                        'source_addresses': [
+                            {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
+                        ],
+                        'destination_ports': ['8080:8085:9099'],
+                    },
+                    {
+                        'type': 'egress',
+                        'protocol': 'tcp',
+                        'destination_addresses': [
+                            {'address_group': 'testgroup'},
+                            {'vrf': 0, 'address': '10.0.1.12', 'length': 32},
+                        ],
+                        'destination_ports': [443],
+                    },
+                ]
+            }), content_type="application/json", HTTP_AUTHORIZATION=auth)
+        self.assertResponse(response, 400)
+
+        response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
+                'name': 'ruleset_faulty1',
+                'rulesets': ['ruleset1'],
+                'rules': [
+                    {
+                        'type': 'ingress',
+                        'protocol': 'tcp',
+                        'source_addresses': [
+                            {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
+                        ],
+                        'destination_ports': ['8080;8085'],
+                    },
+                    {
+                        'type': 'egress',
+                        'protocol': 'tcp',
+                        'destination_addresses': [
+                            {'address_group': 'testgroup'},
+                            {'vrf': 0, 'address': '10.0.1.12', 'length': 32},
+                        ],
+                        'destination_ports': [443],
+                    },
+                ]
+            }), content_type="application/json", HTTP_AUTHORIZATION=auth)
+        self.assertResponse(response, 400)
+
         response = self.client.patch(reverse('socrates_api:network_detail', kwargs={
                 'vrf': 0, 'network': '10.0.0.0', 'length': 24
             }), data=json.dumps({

--- a/socrates_api/tests.py
+++ b/socrates_api/tests.py
@@ -1259,8 +1259,32 @@ class APITests(BaseTests):
         self.assertResponse(response, 201)
 
         response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
+                'name': 'ruleset_range1',
+                'rules': [
+                    {
+                        'type': 'ingress',
+                        'protocol': 'tcp',
+                        'source_addresses': [
+                            {'vrf': 0, 'address': '10.0.0.0', 'length': 8},
+                        ],
+                        'destination_ports': ['4000:4050'],
+                    },
+                    {
+                        'type': 'egress',
+                        'protocol': 'tcp',
+                        'destination_addresses': [
+                            {'address_group': 'testgroup'},
+                            {'vrf': 0, 'address': '10.0.1.12', 'length': 32},
+                            {'vrf': 0, 'address': '10.0.1.13', 'length': 32},
+                        ],
+                        'destination_ports': [443],
+                    },
+                ]
+            }), content_type="application/json", HTTP_AUTHORIZATION=auth)
+        self.assertResponse(response, 201)
+
+        response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
                 'name': 'ruleset_faulty1',
-                'rulesets': ['ruleset1'],
                 'rules': [
                     {
                         'type': 'ingress',
@@ -1284,8 +1308,7 @@ class APITests(BaseTests):
         self.assertResponse(response, 400)
 
         response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
-                'name': 'ruleset_faulty1',
-                'rulesets': ['ruleset1'],
+                'name': 'ruleset_faulty2',
                 'rules': [
                     {
                         'type': 'ingress',
@@ -1309,8 +1332,7 @@ class APITests(BaseTests):
         self.assertResponse(response, 400)
 
         response = self.client.post(reverse('socrates_api:firewall_ruleset_list'), data=json.dumps({
-                'name': 'ruleset_faulty1',
-                'rulesets': ['ruleset1'],
+                'name': 'ruleset_faulty3',
                 'rules': [
                     {
                         'type': 'ingress',


### PR DESCRIPTION
This may allow port ranges in firewall rules. The {destination,source}_ports list children are now charfields validated by validate_firewall_ports(). Tests have been updated, however, I'm not sure if they're updated correctly. This PR should be considered as a work-in-progress

port ranges should be a string containing digits split by :, for example `5000:5059`